### PR TITLE
Add test functions, fix compat, and add CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - run: pip install rich pytest
+      - run: pytest tests/ -v

--- a/guessthedis/__main__.py
+++ b/guessthedis/__main__.py
@@ -28,27 +28,26 @@ from . import test_functions
 __author__ = "Joshua Smith (cmyui)"
 __email__ = "cmyuiosu@gmail.com"
 
-# Opcodes whose arguments are not realistically possible
-# for the user to input (jump targets, conversion flags, etc.)
-OPCODES_WITH_UNPARSEABLE_ARGUMENT = frozenset(
-    dis.opmap[name]
-    for name in (
-        "FOR_ITER",
-        "FORMAT_VALUE",
-        "JUMP_ABSOLUTE",
-        "JUMP_BACKWARD",
-        "JUMP_FORWARD",
-        "JUMP_IF_FALSE_OR_POP",
-        "JUMP_IF_NONE",
-        "JUMP_IF_NOT_EXC_MATCH",
-        "JUMP_IF_NOT_NONE",
-        "JUMP_IF_TRUE_OR_POP",
-        "POP_JUMP_IF_FALSE",
-        "POP_JUMP_IF_NONE",
-        "POP_JUMP_IF_NOT_NONE",
-        "POP_JUMP_IF_TRUE",
+# Opcodes whose arguments are not viable for user input.
+#
+# Jump opcodes (dis.hasjrel, dis.hasjabs) have byte-offset targets
+# that change with any code modification. These are covered
+# automatically across all Python versions via the dis module.
+#
+# Additionally, some opcodes have non-literal argvals:
+# - FORMAT_VALUE (3.10-3.12): argval is a (conversion, has_format_spec) tuple
+# - CONVERT_VALUE (3.13-3.14): argval is a builtin function object (e.g. repr)
+OPCODES_WITH_UNPARSEABLE_ARGUMENT = (
+    frozenset(dis.hasjrel)
+    | frozenset(dis.hasjabs)
+    | frozenset(
+        dis.opmap[name]
+        for name in (
+            "CONVERT_VALUE",  # 3.13+
+            "FORMAT_VALUE",  # 3.10-3.12
+        )
+        if name in dis.opmap
     )
-    if name in dis.opmap
 )
 
 

--- a/guessthedis/__main__.py
+++ b/guessthedis/__main__.py
@@ -28,24 +28,25 @@ from . import test_functions
 __author__ = "Joshua Smith (cmyui)"
 __email__ = "cmyuiosu@gmail.com"
 
-# These opcodes require a line number argument, which is not realistically
-# possible to input by the user, so we'll allow some grace for these.
-OPCODES_WITH_LINE_NUMBER_ARGUMENT = frozenset(
+# Opcodes whose arguments are not realistically possible
+# for the user to input (jump targets, conversion flags, etc.)
+OPCODES_WITH_UNPARSEABLE_ARGUMENT = frozenset(
     dis.opmap[name]
     for name in (
         "FOR_ITER",
+        "FORMAT_VALUE",
         "JUMP_ABSOLUTE",
-        "JUMP_FORWARD",
         "JUMP_BACKWARD",
+        "JUMP_FORWARD",
         "JUMP_IF_FALSE_OR_POP",
-        "JUMP_IF_TRUE_OR_POP",
+        "JUMP_IF_NONE",
         "JUMP_IF_NOT_EXC_MATCH",
         "JUMP_IF_NOT_NONE",
-        "JUMP_IF_NONE",
+        "JUMP_IF_TRUE_OR_POP",
         "POP_JUMP_IF_FALSE",
-        "POP_JUMP_IF_TRUE",
         "POP_JUMP_IF_NONE",
         "POP_JUMP_IF_NOT_NONE",
+        "POP_JUMP_IF_TRUE",
     )
     if name in dis.opmap
 )
@@ -104,34 +105,51 @@ def get_source_code_lines(disassembly_target: Callable[..., Any]) -> list[str]:
     return textwrap.dedent("".join(source_lines[start_line:])).split("\n")
 
 
-# TODO: more generic type for disassembly_target?
-def test_user(disassembly_target: Callable[..., Any]) -> bool:
-    """Test the user on a single function.
-    Returns 1 for correct, -1 for incorrect."""
-    ## print the source code of the function for the user
-    source_code_lines = get_source_code_lines(disassembly_target)
-    max_len_line = max(len(line) for line in source_code_lines)
+def _parse_user_arg(
+    raw: str,
+    expected_argval: object,
+) -> tuple[bool, object]:
+    """Parse a user-provided argument string and compare to the expected value.
 
-    print("Given the following function:")
-    syntax = Syntax(
-        code="\n".join(source_code_lines),
-        lexer="python",
-        theme="monokai",  # TODO: customization?
-        line_numbers=True,
-        code_width=max_len_line + 1,
-    )
-    Console().print(syntax)  # TODO: can i create this once and reuse?
+    Returns (success, parsed_value).
+    """
+    # try ast.literal_eval first (handles quoted strings, numbers, collections)
+    try:
+        parsed = ast.literal_eval(raw)
 
-    ## prompt the user to disassemble the function
-    print("Write the disassembly below (line by line):")
+        if isinstance(expected_argval, frozenset):
+            parsed = frozenset(parsed)
 
-    # TODO: make a higher level version of this where i can disassemble
-    # the constants within the function i am disassembling, so that we
-    # can define things like functions and classes within them
+        if not isinstance(parsed, type(expected_argval)):
+            return False, None
+
+        return parsed == expected_argval, parsed
+    except (ValueError, TypeError, SyntaxError, MemoryError, RecursionError):
+        pass
+
+    # fall back to bare identifier (e.g. variable names in LOAD_FAST)
+    if isinstance(expected_argval, str) and raw == expected_argval:
+        return True, raw
+
+    return False, None
+
+
+def _quiz_instructions(
+    disassembly_target: Callable[..., Any] | types.CodeType,
+) -> None:
+    """Quiz the user on each instruction in the disassembly target.
+
+    Recurses into nested code objects (inner functions, classes, etc.)
+    after the outer disassembly is complete.
+    """
     instruction_iterator = dis.get_instructions(disassembly_target)
+    nested_code_objects: list[types.CodeType] = []
 
-    # quiz them on each operation
     for instruction in instruction_iterator:
+        # collect nested code objects for recursive quizzing
+        if isinstance(instruction.argval, types.CodeType):
+            nested_code_objects.append(instruction.argval)
+
         # loop indefinitely to get valid user input
         while True:
             try:
@@ -181,53 +199,23 @@ def test_user(disassembly_target: Callable[..., Any]) -> bool:
 
             # if this opcode expects arguments,
             # parse them from user input & validate
-            has_unparseable_arg = (
-                instruction.opcode in OPCODES_WITH_LINE_NUMBER_ARGUMENT
-                or isinstance(instruction.argval, types.CodeType)
+            expects_user_arg = (
+                instruction.arg is not None
+                and instruction.opcode not in OPCODES_WITH_UNPARSEABLE_ARGUMENT
+                and not isinstance(instruction.argval, types.CodeType)
             )
-            if instruction.arg is not None and not has_unparseable_arg:
+            if expects_user_arg:
                 if user_input_arg_raw is None:
                     printc("Missing argument(s), please try again", Ansi.LRED)
                     continue
 
-                user_input_args_str = user_input_arg_raw
-                if isinstance(instruction.argval, str):
-                    # compare stripped since leading/trailing whitespace
-                    # is indistinguishable from the opcode delimiter
-                    user_input_arg = user_input_args_str.strip()
-                else:
-                    # argument type is something different - attempt a literal eval
-                    try:
-                        user_input_arg = ast.literal_eval(user_input_args_str)
-
-                        # NOTE: ast.literal_eval only supports strings, bytes,
-                        # numbers, tuples, lists, dicts, sets, booleans, and None
-                        if isinstance(instruction.argval, frozenset):
-                            user_input_arg = frozenset(user_input_arg)
-
-                        assert isinstance(user_input_arg, type(instruction.argval))
-                    except (
-                        AssertionError,
-                        # from ast.eval_literal
-                        ValueError,
-                        TypeError,
-                        SyntaxError,
-                        MemoryError,
-                        RecursionError,
-                    ):
-                        printc(
-                            f"Incorrect argument value: {user_input_args_str}",
-                            Ansi.LRED,
-                        )
-                        continue
-
-                expected_argval = instruction.argval
-                if isinstance(expected_argval, str):
-                    expected_argval = expected_argval.strip()
-
-                if expected_argval != user_input_arg:
+                correct, _ = _parse_user_arg(
+                    user_input_arg_raw,
+                    instruction.argval,
+                )
+                if not correct:
                     printc(
-                        f"Incorrect argument value: {user_input_args_str}",
+                        f"Incorrect argument value: {user_input_arg_raw}",
                         Ansi.LRED,
                     )
                     continue
@@ -241,6 +229,31 @@ def test_user(disassembly_target: Callable[..., Any]) -> bool:
 
             # user input is all correct
             break
+
+    # recurse into nested code objects (inner functions, classes, etc.)
+    for code_obj in nested_code_objects:
+        code_name = getattr(code_obj, "co_qualname", code_obj.co_name)
+        print(f"\nDisassembly of {code_name}:")
+        _quiz_instructions(code_obj)
+
+
+def test_user(disassembly_target: Callable[..., Any]) -> bool:
+    """Test the user on a single function."""
+    source_code_lines = get_source_code_lines(disassembly_target)
+    max_len_line = max(len(line) for line in source_code_lines)
+
+    print("Given the following function:")
+    syntax = Syntax(
+        code="\n".join(source_code_lines),
+        lexer="python",
+        theme="monokai",  # TODO: customization?
+        line_numbers=True,
+        code_width=max_len_line + 1,
+    )
+    Console().print(syntax)  # TODO: can i create this once and reuse?
+
+    print("Write the disassembly below (line by line):")
+    _quiz_instructions(disassembly_target)
 
     printc("Correct!\n", Ansi.LGREEN)
     return True

--- a/guessthedis/test_functions.py
+++ b/guessthedis/test_functions.py
@@ -213,17 +213,14 @@ def match_statement(command: str) -> str:
             return "unknown"
 
 
-# TODO: add support for multiple disassembly definitions
-#       so we can do cool stuff like functions and classes
-
-# @register
-# def create_function() -> None:
-#     def f(x: int, y: int) -> int:
-#         return x + y
+@register
+def create_function() -> None:
+    def f(x: int, y: int) -> int:
+        return x + y
 
 
-# @register
-# def create_class() -> None:
-#     class Player:
-#         def __init__(self, name: str) -> None:
-#             self.name = name
+@register
+def create_class() -> None:
+    class Player:
+        def __init__(self, name: str) -> None:
+            self.name = name

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import dis
+
+import pytest
+
+from guessthedis.__main__ import (
+    OPCODES_WITH_UNPARSEABLE_ARGUMENT,
+    _parse_user_arg,
+    get_source_code_lines,
+)
+from guessthedis import test_functions
+
+
+# -- _parse_user_arg --
+
+
+class TestParseUserArgBareIdentifiers:
+    def test_simple_name(self) -> None:
+        ok, val = _parse_user_arg("x", "x")
+        assert ok is True
+        assert val == "x"
+
+    def test_dotted_name(self) -> None:
+        ok, val = _parse_user_arg("os.path", "os.path")
+        assert ok is True
+
+    def test_wrong_name(self) -> None:
+        ok, _ = _parse_user_arg("y", "x")
+        assert ok is False
+
+
+class TestParseUserArgQuotedStrings:
+    def test_simple_string(self) -> None:
+        ok, val = _parse_user_arg("'hello'", "hello")
+        assert ok is True
+        assert val == "hello"
+
+    def test_string_with_spaces(self) -> None:
+        ok, val = _parse_user_arg("' is '", " is ")
+        assert ok is True
+        assert val == " is "
+
+    def test_string_with_leading_space(self) -> None:
+        ok, val = _parse_user_arg("' years old'", " years old")
+        assert ok is True
+
+    def test_double_quoted(self) -> None:
+        ok, val = _parse_user_arg('"hello"', "hello")
+        assert ok is True
+
+    def test_wrong_string(self) -> None:
+        ok, _ = _parse_user_arg("'wrong'", "right")
+        assert ok is False
+
+
+class TestParseUserArgLiterals:
+    def test_integer(self) -> None:
+        ok, val = _parse_user_arg("42", 42)
+        assert ok is True
+        assert val == 42
+
+    def test_negative_integer(self) -> None:
+        ok, val = _parse_user_arg("-1", -1)
+        assert ok is True
+
+    def test_float(self) -> None:
+        ok, val = _parse_user_arg("3.14", 3.14)
+        assert ok is True
+
+    def test_none(self) -> None:
+        ok, val = _parse_user_arg("None", None)
+        assert ok is True
+        assert val is None
+
+    def test_true(self) -> None:
+        ok, val = _parse_user_arg("True", True)
+        assert ok is True
+
+    def test_false(self) -> None:
+        ok, val = _parse_user_arg("False", False)
+        assert ok is True
+
+    def test_tuple(self) -> None:
+        ok, val = _parse_user_arg("(1, 2)", (1, 2))
+        assert ok is True
+
+    def test_wrong_integer(self) -> None:
+        ok, _ = _parse_user_arg("99", 42)
+        assert ok is False
+
+
+class TestParseUserArgTypeMismatches:
+    def test_string_vs_int(self) -> None:
+        ok, _ = _parse_user_arg("'42'", 42)
+        assert ok is False
+
+    def test_int_vs_string(self) -> None:
+        ok, _ = _parse_user_arg("42", "42")
+        assert ok is False
+
+    def test_int_vs_float(self) -> None:
+        # int and float are not interchangeable in bytecode args
+        ok, _ = _parse_user_arg("3", 3.0)
+        assert ok is False
+
+
+class TestParseUserArgFrozenset:
+    def test_from_set_literal(self) -> None:
+        ok, val = _parse_user_arg("{1, 2, 3}", frozenset({1, 2, 3}))
+        assert ok is True
+        assert val == frozenset({1, 2, 3})
+
+    def test_wrong_elements(self) -> None:
+        ok, _ = _parse_user_arg("{4, 5, 6}", frozenset({1, 2, 3}))
+        assert ok is False
+
+
+# -- get_source_code_lines --
+
+
+class TestGetSourceCodeLines:
+    def test_strips_single_decorator(self) -> None:
+        lines = get_source_code_lines(test_functions.no_op_pass)
+        assert lines[0].startswith("def no_op_pass")
+
+    def test_preserves_body(self) -> None:
+        lines = get_source_code_lines(test_functions.unary_op)
+        source = "\n".join(lines)
+        assert "x = 5" in source
+        assert "return -x" in source
+
+    def test_no_decorator_in_output(self) -> None:
+        lines = get_source_code_lines(test_functions.for_loop)
+        assert not any(line.strip().startswith("@") for line in lines)
+
+    def test_multiline_body_dedented(self) -> None:
+        lines = get_source_code_lines(test_functions.store_collection_types_fast)
+        # the body lines should not have excessive indentation
+        body_lines = [l for l in lines[1:] if l.strip()]
+        for line in body_lines:
+            assert line.startswith("    "), f"Expected 4-space indent: {line!r}"
+
+
+# -- OPCODES_WITH_UNPARSEABLE_ARGUMENT --
+
+
+class TestUnparseableOpcodes:
+    def test_covers_all_jump_opcodes(self) -> None:
+        all_jumps = frozenset(dis.hasjrel) | frozenset(dis.hasjabs)
+        missing = all_jumps - OPCODES_WITH_UNPARSEABLE_ARGUMENT
+        assert missing == set(), (
+            f"Jump opcodes missing from skip set: "
+            f"{sorted(dis.opname[op] for op in missing)}"
+        )
+
+    def test_format_value_included_if_present(self) -> None:
+        if "FORMAT_VALUE" in dis.opmap:
+            assert dis.opmap["FORMAT_VALUE"] in OPCODES_WITH_UNPARSEABLE_ARGUMENT
+
+    def test_convert_value_included_if_present(self) -> None:
+        if "CONVERT_VALUE" in dis.opmap:
+            assert dis.opmap["CONVERT_VALUE"] in OPCODES_WITH_UNPARSEABLE_ARGUMENT
+
+
+# -- test_functions registry --
+
+
+class TestFunctionRegistry:
+    def test_all_functions_disassemble(self) -> None:
+        for func in test_functions.functions:
+            # should not raise
+            instructions = list(dis.get_instructions(func))
+            assert len(instructions) > 0, f"{func.__name__} has no instructions"
+
+    def test_functions_are_registered(self) -> None:
+        assert len(test_functions.functions) > 0
+
+    def test_no_duplicate_names(self) -> None:
+        names = [f.__name__ for f in test_functions.functions]
+        assert len(names) == len(set(names))


### PR DESCRIPTION
## Summary
- Add 17 new test functions organized by difficulty (beginner, intermediate, advanced), covering ternary expressions, boolean short-circuit, f-strings, unpacking, try/except, context managers, chained comparisons, star unpacking, del, walrus operator, generators, closures, match statements, and nested function/class definitions
- Fix Python 3.10-3.14 compatibility: use `dis.hasjrel`/`dis.hasjabs` for jump opcodes, `instruction.arg is not None` instead of deprecated `dis.HAVE_ARGUMENT`, `instruction.offset` for real bytecode offsets
- Unified argument parsing via `ast.literal_eval` with bare-identifier fallback (fixes whitespace in string constants like f-string parts)
- Recursive disassembly of nested code objects (inner functions, classes)
- Add unit tests (31 tests) covering `_parse_user_arg`, `get_source_code_lines`, opcode skip set, and function registry
- Add GitHub Actions CI running tests on Python 3.10-3.14

## Test plan
- [x] 31 unit tests pass on Python 3.10, 3.11, 3.12, 3.13, 3.14
- [x] Full game playthrough (30/30 correct) verified on all 5 Python versions
- [ ] CI passes on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)